### PR TITLE
[C#] use standard unclosed-string behavior

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1416,8 +1416,8 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
-    - match: '[^"]*$'
-      scope: invalid.string.newline.cs
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
       pop: true
 
   format_string:
@@ -1428,8 +1428,8 @@ contexts:
       pop: true
     - include: escaped
     - include: string_interpolation
-    - match: '[^"{]*$'
-      scope: invalid.string.newline.cs
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
       pop: true
 
   long_format_string:

--- a/C#/tests/syntax_test_Generics.cs
+++ b/C#/tests/syntax_test_Generics.cs
@@ -66,12 +66,12 @@ string interpolated = $"inner {t.Word,-30} {t.Responsibility,8:F2} {{";
 ///                                                                  ^ punctuation.definition.string.end
 
 string unclosed_string = "inner ;
-///                             ^ invalid.string.newline
+///                              ^ invalid.illegal.unclosed-string
 string bar = "bar"
 /// <- storage.type
 
 string unclosed_interpolation = $"inner {t.Word};
-///                                             ^ invalid.string.newline
+///                                              ^ invalid.illegal.unclosed-string.cs
 string foo = "foo";
 /// <- storage.type
 


### PR DESCRIPTION
This PR changes the unclosed string behavior in the C# syntax to match that of the other syntaxes, like Python, which scopes the new line character as invalid, which is less jarring than having the whole string appear as invalid.