### PR TITLE
[Regular Expression] Reorganize/Split backslashes context

### DIFF
--- a/Regular Expressions/RegExp (Basic).sublime-syntax
+++ b/Regular Expressions/RegExp (Basic).sublime-syntax
@@ -46,7 +46,9 @@ contexts:
 
   base-common:
     - include: character-classes
-    - include: backslashes
+    - include: anchors
+    - include: backrefs
+    - include: switches
     - include: escaped-chars
     - include: charsets
     - include: operators
@@ -221,20 +223,21 @@ contexts:
       scope: constant.character.escape.regexp
       pop: 1
 
-  backslashes:
+  anchors:
     - match: \\[bBAZzG]|[\^$]
       scope: keyword.control.anchors.regexp
       push: maybe-unexpected-quantifiers
-    - include: backslash-q-literals
-    - match: \\K
-      scope: keyword.control.regexp
-      push: maybe-unexpected-quantifiers
+
+  backrefs:
     - match: \\([1-9]\d*)
       scope: keyword.other.backref-and-recursion.regexp
       captures:
         1: variable.other.backref-and-recursion.regexp
 
-  backslash-q-literals:
+  switches:
+    - match: \\K
+      scope: keyword.control.regexp
+      push: maybe-unexpected-quantifiers
     - match: \\Q
       scope: keyword.control.regexp
       push: literal-until-backslash-e

--- a/Regular Expressions/RegExp.sublime-syntax
+++ b/Regular Expressions/RegExp.sublime-syntax
@@ -110,11 +110,14 @@ contexts:
       scope: keyword.operator.intersection.regexp
     - include: charsets
 
-  backslashes:
+  anchors:
     - meta_prepend: true
     - match: \\[><]
       scope: keyword.control.anchors.regexp
       push: maybe-unexpected-quantifiers
+
+  backrefs:
+    - meta_prepend: true
     - match: \\[kg](?:(<)([^>]+)(>)|(')([^']+)(')|(\{)([^}]+)(\})|(-?\d+))
       scope: keyword.other.backref-and-recursion.regexp
       captures:


### PR DESCRIPTION
This commit splits `backslashes` context into anchors, backrefs, backslashes.

The idea is to enable inerhited syntaxes to address those different kinds of control keywords independently.

I am not sure about `switches` context name.

EDIT: Force-pushed a change, because I oversaw backslashes context in Regexp.sublime-syntax