### PR TITLE
[Regular Expressions] Fix overlapping meta.group scopes

### DIFF
--- a/Regular Expressions/RegExp (Basic).sublime-syntax
+++ b/Regular Expressions/RegExp (Basic).sublime-syntax
@@ -125,61 +125,66 @@ contexts:
 
   group-body:
     - meta_scope: meta.group.regexp
-    - match: \)
-      scope: keyword.control.group.regexp
-      pop: 1
+    - include: group-end
     - include: ingroup-xmode-on
     - include: base
     - include: literals
 
   group-body-extended:
     - meta_scope: meta.group.extended.regexp
-    - match: \)
-      scope: keyword.control.group.regexp
-      pop: 1
+    - include: group-end
     - include: ingroup-xmode-off
     - include: base-extended
     - include: literals
 
+  group-end:
+    - match: \)
+      scope: keyword.control.group.regexp
+      pop: 1
+
   ingroup-xmode-on:
     # Activates 'x' mode
     - match: (\()({{activate_x_mode}})(\))
-      scope: meta.group.regexp
       captures:
+        0: meta.group.extended.regexp
         1: keyword.control.group.regexp
         2: storage.modifier.mode.regexp
         3: keyword.control.group.regexp
-      set: [group-body-extended, maybe-unexpected-quantifiers]
+      pop: 1  # pop `group-body` to avoid overlapping `meta.group`
+      push: [group-body-extended, maybe-unexpected-quantifiers]
 
   ingroup-xmode-off:
     # Deactivates 'x' mode
     - match: (\()({{deactivate_x_mode}})(\))
-      scope: meta.group.extended.regexp
       captures:
+        0: meta.group.regexp
         1: keyword.control.group.regexp
         2: storage.modifier.mode.regexp
         3: keyword.control.group.regexp
-      set: [group-body, maybe-unexpected-quantifiers]
+      pop: 1  # pop `group-body-extended` to avoid overlapping `meta.group`
+      push: [group-body, maybe-unexpected-quantifiers]
 
   xmode-on:
     # Activates 'x' mode
     - match: (\()({{activate_x_mode}})(\))
-      scope: meta.group.regexp
       captures:
+        0: meta.group.extended.regexp
         1: keyword.control.group.regexp
         2: storage.modifier.mode.regexp
         3: keyword.control.group.regexp
-      set: [base-literal-extended, maybe-unexpected-quantifiers]
+      pop: 1 # pop `base-literal` to avoid overlapping `meta.` (if any)
+      push: [base-literal-extended, maybe-unexpected-quantifiers]
 
   xmode-off:
     # Deactivates 'x' mode
     - match: (\()({{deactivate_x_mode}})(\))
-      scope: meta.group.extended.regexp
       captures:
+        0: meta.group.regexp
         1: keyword.control.group.regexp
         2: storage.modifier.mode.regexp
         3: keyword.control.group.regexp
-      set: [base-literal, maybe-unexpected-quantifiers]
+      pop: 1 # pop `base-literal-extended` to avoid overlapping `meta.` (if any)
+      push: [base-literal, maybe-unexpected-quantifiers]
 
   charsets:
     - match: (\[\^?)\]?

--- a/Regular Expressions/syntax_test_regexp.re
+++ b/Regular Expressions/syntax_test_regexp.re
@@ -229,6 +229,14 @@ where escape characters are ignored.\).
 ###################
 
 (?x)
+# <- meta.group.extended.regexp - meta.group meta.group
+#^^^ meta.group.extended.regexp - meta.group meta.group
+#^^ storage.modifier.mode.regexp
+#   ^ meta.ignored-whitespace
+
+(?x)
+# <- meta.group.extended.regexp - meta.group meta.group
+#^^^ meta.group.extended.regexp - meta.group meta.group
 #^^ storage.modifier.mode.regexp
 #   ^ meta.ignored-whitespace
 
@@ -248,16 +256,84 @@ where escape characters are ignored.\).
 
  (?-ix)
 # <- meta.ignored-whitespace
+#^^^^^^ meta.group.regexp - meta.group meta.group
+#^ keyword.control.group.regexp
 # ^^^^ storage.modifier.mode.regexp
+#     ^ keyword.control.group.regexp
+
+# not a comment
+# <- - comment
+
+ (?-ix)
+# <- - meta.ignored-whitespace
+#^^^^^^ meta.group.regexp - meta.group meta.group
+#^ keyword.control.group.regexp
+# ^^^^ storage.modifier.mode.regexp
+#     ^ keyword.control.group.regexp
 
 # not a comment
 # <- - comment
 
 (
+# <- meta.group.regexp keyword.control.group.regexp
+#^ meta.group.regexp - keyword
     (?x)
+#  ^ meta.group.regexp
+#   ^^^^ meta.group.extended.regexp meta.group.extended.regexp - meta.group meta.group meta.group
+#   ^ keyword.control.group.regexp
+#    ^^ storage.modifier.mode.regexp
+#      ^ keyword.control.group.regexp
     # comment
 #   ^^^^^^^^^ comment
-   (?-x)
+    (?x)
+#   ^^^^ meta.group.extended.regexp meta.group.extended.regexp - meta.group meta.group meta.group
+#   ^ keyword.control.group.regexp
+#    ^^ storage.modifier.mode.regexp
+#      ^ keyword.control.group.regexp
+    # comment
+#   ^^^^^^^^^ comment
+    (?-x)
+#   ^^^^^ meta.group.regexp meta.group.regexp - meta.group meta.group meta.group
+    # comment
+#   ^^^^^^^^^ - comment
+    (?-x)
+#   ^^^^^ meta.group.regexp meta.group.regexp - meta.group meta.group meta.group
+    # comment
+#   ^^^^^^^^^ - comment
+    (?:
+#  ^ meta.group.regexp - meta.group meta.group
+#   ^^^^ meta.group.regexp meta.group.regexp
+        (?x)
+#      ^ meta.group.regexp meta.group.regexp - meta.group meta.group meta.group
+#       ^^^^ meta.group.regexp meta.group.extended.regexp meta.group.extended.regexp - meta.group meta.group meta.group meta.group
+#           ^ meta.group.regexp meta.group.extended.regexp - meta.group meta.group meta.group
+#       ^ keyword.control.group.regexp
+#        ^^ storage.modifier.mode.regexp
+#          ^ keyword.control.group.regexp
+        # comment
+#       ^^^^^^^^^ comment
+        (?x)
+#      ^ meta.group.regexp meta.group.extended.regexp - meta.group meta.group meta.group
+#       ^^^^ meta.group.regexp meta.group.extended.regexp meta.group.extended.regexp - meta.group meta.group meta.group meta.group
+#           ^ meta.group.regexp meta.group.extended.regexp - meta.group meta.group meta.group
+#       ^ keyword.control.group.regexp
+#        ^^ storage.modifier.mode.regexp
+#          ^ keyword.control.group.regexp
+        # comment
+#       ^^^^^^^^^ comment
+        (?-x)
+#       ^^^^^ meta.group.regexp meta.group.regexp meta.group.regexp - meta.group meta.group meta.group meta.group
+        # comment
+#       ^^^^^^^^^ - comment
+        (?-x)
+#       ^^^^^ meta.group.regexp meta.group.regexp meta.group.regexp - meta.group meta.group meta.group meta.group
+        # comment
+#       ^^^^^^^^^ - comment
+    ) # no comment
+#^^^^ meta.group.regexp meta.group.regexp
+#    ^^^^^^^^^^^^^^ meta.group.regexp - meta.group meta.group
+#   ^ keyword.control.group.regexp
+#     ^^^^^^^^^^^^ - comment
 ) # no comment
 # <- keyword.control.group
 # ^ - comment
@@ -358,7 +434,7 @@ where escape characters are ignored.\).
 #                 ^^ variable.other.backref-and-recursion.regexp
 
 (?x)(?<named_group>test)(?&named_group)(?-x)
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.extended
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.extended.regexp
 #    ^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
 #      ^^^^^^^^^^^ entity.name.capture-group.regexp
 #     ^ punctuation.definition.capture-group-name.begin.regexp
@@ -412,8 +488,9 @@ where escape characters are ignored.\).
 #      ^ keyword.control.set.regexp
 #       ^ keyword.other.any.regexp
 #        ^^^ keyword.other.backref-and-recursion.regexp
+#           ^^^^ meta.group.regexp meta.group.regexp
+#            ^^ storage.modifier.mode.regexp
 #               ^ keyword.control.anchors.regexp
-#            ^^ meta.group.regexp meta.group.regexp storage.modifier.mode.regexp
 #                  ^^ constant.character.escape.regexp
 #                  ^^^ - keyword.other.backref-and-recursion.regexp
 
@@ -582,7 +659,9 @@ where escape characters are ignored.\).
 (*FA)
 #^ invalid.illegal.unexpected-quantifier.regexp
 (?-x)
-#^^^^ meta.group.extended
+# <- meta.group.regexp keyword.control.group.regexp
+#^^^ meta.group.regexp storage.modifier.mode.regexp
+#   ^ meta.group.regexp keyword.control.group.regexp
 
  \Qtext.here.is\dliteral)\E{1,2}{1,2}{1,2}
 #^^ keyword.control
@@ -602,35 +681,7 @@ where escape characters are ignored.\).
 #                                          ^^^ meta.group.extended meta.group.extended invalid.illegal.unexpected-quantifier
 #                                               ^ meta.ignored-whitespace - meta.group
 (?:(?x-i))
-#  ^^^^^^ meta.group.extended meta.group.extended
-(?-x)
-
-(
-# <- meta.group.regexp keyword.control.group.regexp
-#^ meta.group.regexp - keyword
-    (?x)
-#  ^ meta.group.regexp
-#   ^^^^ meta.group.regexp meta.group.extended.regexp
-#   ^ keyword.control.group.regexp
-#    ^^ storage.modifier.mode.regexp
-#      ^ keyword.control.group.regexp
-    # comment
-#   ^^^^^^^^^ comment
-    (?x)
-#   ^^^^ meta.group.extended.regexp meta.group.extended.regexp
-#   ^ keyword.control.group.regexp
-#    ^^ storage.modifier.mode.regexp
-#      ^ keyword.control.group.regexp
-    # comment
-#   ^^^^^^^^^ comment
-    (?-x)
-#   ^^^^^ meta.group.extended.regexp meta.group.regexp
-    # comment
-#   ^^^^^^^^^ - comment
-    (?-x)
-#   ^^^^^ meta.group.regexp meta.group.regexp
-    # comment
-#   ^^^^^^^^^ - comment
-) # no comment
-# <- keyword.control.group
-# ^ - comment
+# <- meta.group.extended.regexp - meta.group meta.group
+#^^ meta.group.extended.regexp - meta.group meta.group
+#  ^^^^^^ meta.group.extended.regexp meta.group.extended.regexp
+#        ^ meta.group.extended.regexp - meta.group meta.group


### PR DESCRIPTION
Global modifiers in a group cause a 3rd `meta.group` to be assigned due to overlapping meta scopes of the group-body contexts.

This PR fixes overlapping meta.groups by first popping the former group-body context before pushing the new one on stack.

I am not very confident about `meta.group` vs. `meta.group.extended` to be a suitable solution to distinguish basic/extended mode because it doesn't address/cover global patterns (not covered by a group) and creates some odd `meta.group` stacking if global modifiers are part of a group.

1. Maybe it's more consistent to just scope all groups `meta.group.regexp`? 
2. Not sure if `meta.group` is suitable for global modifiers such as `(?x)`. Maybe a `meta.paren` would be more suitable? May depend on future decisions about scope names in general though.


I already experiment with a dedicated `meta.mode.[basic|extended]` scope which applies everywhere, but this may be a dedicated PR.