### PR TITLE
[SQL] Enable variable interpolations

### DIFF
--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -4,6 +4,8 @@ name: SQL
 scope: source.sql
 version: 2
 
+extends: Packages/SQL/MySQL.sublime-syntax
+
 file_extensions:
   - sql
   - ddl
@@ -13,8 +15,3 @@ first_line_match: |-
   (?xi:
     ^ \s* -- .*? -\*- .*? \bsql\b .*? -\*-  # editorconfig
   )
-
-contexts:
-  main:
-    - include: scope:source.sql.mysql
-      apply_prototype: true


### PR DESCRIPTION
This commit turns SQL.sublime-syntax into an inherited syntax
of MySQL.sublime-syntax in order to properly support variable
interpolation in Ruby HEREDOCs.

The Ruby package contains a SQL (for Ruby).sublime-syntax, which
inherits from SQL.sublime-syntax in order to inject variable
interpolation via `prototype`.

This mechanism does only work if SQL.sublime-syntax inherits from
the desired dialect as well.