### PR TITLE
[SQL] Rename PostgresSQL to PostgreSQL

### DIFF
--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-name: PostgresSQL
+name: PostgreSQL
 scope: source.sql.postgresql
 version: 2
 extends: Packages/SQL/MySQL.sublime-syntax

--- a/SQL/tests/syntax/syntax_test_postgres.sql
+++ b/SQL/tests/syntax/syntax_test_postgres.sql
@@ -1,4 +1,4 @@
--- SYNTAX TEST "Packages/SQL/PostgresSQL.sublime-syntax"
+-- SYNTAX TEST "Packages/SQL/PostgreSQL.sublime-syntax"
 
 CREATE TABLE test1 (a character(4));
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.create


### PR DESCRIPTION
Hi!

So here comes my first PR. I'd like to suggest to use the name PostgreSQL instead of *PostgresSQL* because it's rather unusual afaics.

Repeating reasons from the commit message:

* The official site rarely refers to is as "PostgresSQL".
* The name "PostgreSQL" has way more results in search engines.
* The Wikipedia page never uses "PostgresSQL".