### PR TITLE
Separate column declaration and reference lists

### DIFF
--- a/SQL/Cassandra.sublime-syntax
+++ b/SQL/Cassandra.sublime-syntax
@@ -34,7 +34,7 @@ contexts:
       scope: keyword.other.ddl.sql
       push:
         - ddl-create-target
-        - ddl-table-creation-columns
+        - maybe-column-declaration-list
         - ddl-create-type-condition
 
   ddl-alter-common:
@@ -59,21 +59,6 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.toc-list.full-identifier.sql entity.name.type.cql
     - include: immediately-pop
-
-  inside-ddl-table-creation-columns:
-    - meta_scope: meta.group.table-columns.sql
-    - match: \)
-      scope: punctuation.section.group.end.sql
-      pop: 1
-    - match: \b(?i:(primary\s+key))\s*(\()
-      captures:
-        1: storage.modifier.cql
-        2: meta.group.partition-key.cql punctuation.section.group.begin.cql
-      push: inside-partition-key
-    - match: \b(?i:primary\s+key)\b
-      scope: storage.modifier.cql
-    - include: expressions
-    - include: ddl-creation-column
 
   inside-partition-key:
     - meta_content_scope: meta.group.partition-key.cql
@@ -182,6 +167,23 @@ contexts:
     - include: expressions
     - match: '{{simple_identifier}}'
       scope: meta.mapping.key.cql string.unquoted.cql
+
+###[ COLUMN DECLARATIONS ]#####################################################
+
+  inside-column-declaration-list:
+    - meta_scope: meta.group.table-columns.sql
+    - match: \)
+      scope: punctuation.section.group.end.sql
+      pop: 1
+    - match: \b(?i:(primary\s+key))\s*(\()
+      captures:
+        1: storage.modifier.cql
+        2: meta.group.partition-key.cql punctuation.section.group.begin.cql
+      push: inside-partition-key
+    - match: \b(?i:primary\s+key)\b
+      scope: storage.modifier.cql
+    - include: expressions
+    - include: column-declaration
 
 ###[ TYPES ]###################################################################
 

--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -93,13 +93,6 @@ contexts:
       pop: 1
     - include: else-pop
 
-  inside-ddl-table-creation-columns:
-    - meta_prepend: true
-    - match: \b(?i:auto_increment)\b
-      scope: keyword.other.mysql
-    - match: (?i:\s*\b(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is)\s+)
-      scope: keyword.other.object-comments.sql
-
 ###[ DML STATEMENTS ]##########################################################
 
   dml-statements:
@@ -137,6 +130,15 @@ contexts:
     - match: (?=#)
       pop: 1
     - include: comments
+
+###[ COLUMN DECLARATIONS ]#####################################################
+
+  inside-column-declaration-list:
+    - meta_prepend: true
+    - match: \b(?i:auto_increment)\b
+      scope: keyword.other.mysql
+    - match: \b(?i:(comment\s+on\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\s+.*?\s+(is))
+      scope: keyword.other.object-comments.sql
 
 ###[ TYPES ]###################################################################
 

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -80,11 +80,6 @@ contexts:
     - match: \b(?i:extension|domain)\b
       scope: keyword.other.psql
 
-  inside-ddl-table-creation-columns:
-    - meta_prepend: true
-    - match: \b(?i:unique)\b
-      scope: keyword.other.psql
-
 ###[ EXPRESSIONS ]#############################################################
 
   expressions:
@@ -99,6 +94,13 @@ contexts:
       scope: keyword.operator.range.psql
     - match: \b(?i:return)\b
       scope: keyword.control.flow.return.psql
+
+###[ COLUMN DECLARATIONS ]#####################################################
+
+  inside-column-declaration-list:
+    - meta_prepend: true
+    - match: \b(?i:unique)\b
+      scope: keyword.other.psql
 
 ###[ OPERATORS ]###############################################################
 

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -93,7 +93,7 @@ contexts:
       scope: keyword.other.ddl.sql
       push:
         - ddl-create-target
-        - ddl-table-creation-columns
+        - maybe-column-declaration-list
         - create-table-condition
     - match: \b(?i:create)\b
       scope: keyword.other.ddl.sql
@@ -121,31 +121,6 @@ contexts:
       push:
         - ddl-alter-target
         - ddl-target
-
-  ddl-table-creation-columns:
-    - match: \(
-      scope: punctuation.section.group.begin.sql
-      set: inside-ddl-table-creation-columns
-
-  inside-ddl-table-creation-columns:
-    - meta_scope: meta.group.table-columns.sql
-    - match: \)
-      scope: punctuation.section.group.end.sql
-      pop: 1
-    - match: \b(?i:constraint)\b
-      scope: storage.modifier.sql
-      push: expect-constraint-name
-    - include: column-modifiers
-    - include: expressions
-    - include: ddl-creation-column
-
-  ddl-creation-column:
-    - match: (?=\S)
-      push:
-        - after-type
-        - expect-type
-        - column-name-declaration
-        - single-identifier
 
   ddl-create-target:
     - meta_scope: meta.create.sql
@@ -507,7 +482,36 @@ contexts:
       pop: 1
     - include: else-pop
 
-###[ COLUMN MODIFIERS ]########################################################
+###[ COLUMN DECLARATIONS ]#####################################################
+
+  maybe-column-declaration-list:
+    - include: column-declaration-list
+    - include: else-pop
+
+  column-declaration-list:
+    - match: \(
+      scope: punctuation.section.group.begin.sql
+      set: inside-column-declaration-list
+
+  inside-column-declaration-list:
+    - meta_scope: meta.group.table-columns.sql
+    - match: \)
+      scope: punctuation.section.group.end.sql
+      pop: 1
+    - match: \b(?i:constraint)\b
+      scope: storage.modifier.sql
+      push: expect-constraint-name
+    - include: column-modifiers
+    - include: expressions
+    - include: column-declaration
+
+  column-declaration:
+    - match: (?=\S)
+      push:
+        - after-type
+        - expect-type
+        - column-name-declaration
+        - single-identifier
 
   maybe-column-modifier:
     - include: column-modifiers
@@ -523,18 +527,28 @@ contexts:
         | default
         )\b
       scope: storage.modifier.sql
-      push: maybe-column-reference
+      push: maybe-column-reference-list
     - match: \b(?i:references)\b
       scope: storage.modifier.sql
       push:
-        - maybe-column-reference
+        - maybe-column-reference-list
         - expect-table-name
 
-  maybe-column-reference:
+  maybe-column-reference-list:
+    - include: column-reference-list
+    - include: else-pop
+
+  column-reference-list:
     - match: \(
       scope: punctuation.section.group.begin.sql
-      set: inside-ddl-table-creation-columns
-    - include: else-pop
+      set: inside-column-reference-list
+
+  inside-column-reference-list:
+    - meta_scope: meta.group.table-columns.sql
+    - match: \)
+      scope: punctuation.section.group.end.sql
+      pop: 1
+    - include: expressions-or-column-names
 
 ###[ TYPES ]###################################################################
 

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -396,7 +396,7 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.sql
       pop: 1
-    - include: main
+    - include: sql
 
   set:
     - include: else-pop

--- a/SQL/TSQL.sublime-syntax
+++ b/SQL/TSQL.sublime-syntax
@@ -86,21 +86,6 @@ contexts:
     - match: \b(?i:proc|unique|clustered|nonclustered)\b
       scope: keyword.other.ddl.sql
 
-  ddl-table-creation-columns:
-    - match: \(
-      scope: punctuation.section.group.begin.sql
-      set:
-        - maybe-with-table-options
-        - maybe-filegroup
-        - inside-ddl-table-creation-columns
-
-  inside-ddl-table-creation-columns:
-    - meta_prepend: true
-    - match: \b(?i:rowguidcol|clustered|nonclustered)\b
-      scope: storage.modifier.tsql
-    - match: \b(?i:period\s+for\s+system_time)\b
-      scope: storage.modifier.tsql
-
 ###[ DML STATEMENTS ]##########################################################
 
   dml-statements:
@@ -244,7 +229,7 @@ contexts:
       scope: keyword.other.dml.sql
       push:
         - cte-as
-        - cte-column-list
+        - maybe-column-reference-list
         - expect-cte-table-name
     - match: \b(?i:with)\b #(?=\s*(?:\[\w+\]|\w+)\s*\bas\b)
       scope: keyword.other.dml.sql
@@ -259,13 +244,9 @@ contexts:
     - match: ','
       scope: punctuation.separator.sequence.cte.tsql
       push:
-        - cte-column-list
+        - maybe-column-reference-list
         - expect-cte-table-name
     - include: expressions
-
-  cte-column-list:
-    - include: ddl-table-creation-columns
-    - include: else-pop
 
 ###[ EXPRESSIONS ]#############################################################
 
@@ -476,8 +457,8 @@ contexts:
       scope: meta.group.tsql punctuation.section.group.end.tsql
       pop: 1
     - include: comma-separators
+    - include: column-reference-list
     - include: literals-and-variables
-    - include: ddl-table-creation-columns
     - include: expect-index-names
 
   inside-optimize-for-group:
@@ -686,8 +667,25 @@ contexts:
   maybe-with-column-definition:
     - match: \b(?i:with)\b
       scope: keyword.other.tsql
-      set: ddl-table-creation-columns
+      set: maybe-column-declaration-list
     - include: else-pop
+
+###[ COLUMN DECLARATIONS ]#####################################################
+
+  maybe-column-declaration-list:
+    - match: \(
+      scope: punctuation.section.group.begin.sql
+      set:
+        - maybe-with-table-options
+        - maybe-filegroup
+        - inside-column-declaration-list
+
+  inside-column-declaration-list:
+    - meta_prepend: true
+    - match: \b(?i:rowguidcol|clustered|nonclustered)\b
+      scope: storage.modifier.tsql
+    - match: \b(?i:period\s+for\s+system_time)\b
+      scope: storage.modifier.tsql
 
 ###[ TYPES ]###################################################################
 

--- a/SQL/tests/syntax/syntax_test_mysql.sql
+++ b/SQL/tests/syntax/syntax_test_mysql.sql
@@ -21,8 +21,12 @@ SELECT "My -- Crazy Column Name" FROM my_table;
 SELECT "My /* Crazy Column Name" FROM my_table;
 --         ^^ - comment - punctuation
 
+CREATE TABLE foo
+-- ^^^^^^^^^ keyword.other.ddl
+--           ^^^ entity.name.struct
 
 ;CREATE TABLE foo (id INTEGER PRIMARY KEY);
+-- <- punctuation.terminator.statement.sql
  -- <- meta.create keyword.other.ddl
 --^^^^^ keyword.other.ddl
 --      ^^^^^ keyword.other


### PR DESCRIPTION
The way how T-SQL has overridden `ddl-table-creation-columns` context may have caused syntax issues in other expressions, which just need a list of columns.

Hence it is separated into a `column-declaration-list` and a `column-reference-list`, both reused where appropriate.

They are both organized next to each other in source code as it seems most consistent.

A missing bailout was the initial inspiration to think about it.