### PR TITLE
[C#] Some proposals for string literals

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1720,11 +1720,7 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
-    - match: '(\{)(\d+)'
-      captures:
-        1: punctuation.definition.placeholder.begin.cs
-        2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: inside_string_placeholder
+    - include: extended_string_placeholders
 
   inside_string:
     - meta_include_prototype: false
@@ -1734,11 +1730,7 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
-    - match: '(\{)(\d+)'
-      captures:
-        1: punctuation.definition.placeholder.begin.cs
-        2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: inside_string_placeholder
+    - include: extended_string_placeholders
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
@@ -1866,14 +1858,28 @@ contexts:
         1: punctuation.definition.placeholder.begin.cs
         2: meta.number.integer.decimal.cs constant.numeric.value.cs invalid.illegal.unclosed-string-placeholder.cs
 
-  inside_string_placeholder:
+  extended_string_placeholders:
+    - match: '(\{)(\d+)'
+      captures:
+        1: punctuation.definition.placeholder.begin.cs
+        2: meta.number.integer.decimal.cs constant.numeric.value.cs
+      push: inside_extended_string_placeholder
+
+  inside_extended_string_placeholder:
     - meta_scope: constant.other.placeholder.cs
     - include: string_placeholder_end
     - include: string_placeholder_format
     - match: '[^"}]+'
       scope: invalid.illegal.unexpected-character-in-placeholder.cs
 
-  inside_long_string_placeholder:
+  extended_long_string_placeholders:
+    - match: '(\{)(\d+)'
+      captures:
+        1: punctuation.definition.placeholder.begin.cs
+        2: meta.number.integer.decimal.cs constant.numeric.value.cs
+      push: inside_extended_long_string_placeholder
+
+  inside_extended_long_string_placeholder:
     - meta_scope: constant.other.placeholder.cs
     - include: string_placeholder_end
     - include: long_string_placeholder_format
@@ -1940,15 +1946,11 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.raw.cs
     - include: long_string_escaped
-    - include: string_placeholders
-    - match: '(\{)(\d+)'
-      captures:
-        1: punctuation.definition.placeholder.begin.cs
-        2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: inside_long_string_placeholder
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
+    - include: string_placeholders
+    - include: extended_long_string_placeholders
 
   escaped:
     - match: '{{escaped_char}}'

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -152,7 +152,7 @@ contexts:
               pop: true
         - match: '"'
           scope: punctuation.definition.string.begin.cs
-          push: string
+          push: inside_string
         - include: option_done
 
     - match: '(pragma)\s+(warning)\b'
@@ -1683,36 +1683,36 @@ contexts:
   strings:
     - match: '("""+)'
       scope: punctuation.definition.string.begin.cs
-      push: raw_string_literal
+      push: inside_raw_string_literal
     - match: '"'
       scope: punctuation.definition.string.begin.cs
-      push: string
+      push: inside_string
     # interpolated strings
     - match: '\$("""+)'
       scope: punctuation.definition.string.begin.cs
-      push: raw_format_string
+      push: inside_raw_format_string
     - match: '\$\$("""+)'
       scope: punctuation.definition.string.begin.cs
-      push: raw_format_string_2
+      push: inside_raw_format_string_2
     - match: '@\$("""+)'
       scope: punctuation.definition.string.begin.cs
-      push: raw_format_string_literal
+      push: inside_raw_format_string_literal
     - match: '@\$\$("""+)'
       scope: punctuation.definition.string.begin.cs
-      push: raw_format_string_literal_2
+      push: inside_raw_format_string_literal_2
     - match: '\$"'
       scope: punctuation.definition.string.begin.cs
-      push: format_string
+      push: inside_format_string
     # multi-line strings
     - match: '@"'
       scope: punctuation.definition.string.begin.cs
-      push: long_string
+      push: inside_long_string
     # interpolated multi-line strings
     - match: '(@\$|\$@)"'
       scope: punctuation.definition.string.begin.cs
-      push: long_format_string
+      push: inside_long_format_string
 
-  raw_string_literal:
+  inside_raw_string_literal:
     - meta_include_prototype: false
     - meta_scope: string.quoted.triple.cs
     - include: string_escaped
@@ -1724,9 +1724,9 @@ contexts:
       captures:
         1: punctuation.definition.placeholder.begin.cs
         2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: string_placeholder
+      push: inside_string_placeholder
 
-  string:
+  inside_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.cs
     - include: string_escaped
@@ -1738,12 +1738,12 @@ contexts:
       captures:
         1: punctuation.definition.placeholder.begin.cs
         2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: string_placeholder
+      push: inside_string_placeholder
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
 
-  format_string:
+  inside_format_string:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.double.cs
     - match: '"'
@@ -1763,7 +1763,7 @@ contexts:
       scope: invalid.illegal.unclosed-string.cs
       pop: true
 
-  raw_format_string:
+  inside_raw_format_string:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
     - match: '\1'
@@ -1783,7 +1783,7 @@ contexts:
       scope: invalid.illegal.unclosed-string.cs
       pop: true
 
-  raw_format_string_literal:
+  inside_raw_format_string_literal:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
     - match: '\1'
@@ -1802,7 +1802,7 @@ contexts:
       scope: invalid.illegal.unclosed-string.cs
       pop: true
 
-  raw_format_string_2:
+  inside_raw_format_string_2:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
     - match: '\1'
@@ -1819,7 +1819,7 @@ contexts:
         - include: string_placeholder_format
         - include: string_interpolation_2
 
-  raw_format_string_literal_2:
+  inside_raw_format_string_literal_2:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.triple.cs
     - match: '\1'
@@ -1835,7 +1835,7 @@ contexts:
         - include: string_placeholder_format
         - include: string_interpolation_2
 
-  long_format_string:
+  inside_long_format_string:
     - meta_include_prototype: false
     - meta_scope: meta.string.interpolated.cs string.quoted.double.raw.cs
     - include: long_string_escaped
@@ -1867,6 +1867,20 @@ contexts:
         2: meta.number.integer.decimal.cs constant.numeric.value.cs invalid.illegal.unclosed-string-placeholder.cs
 
   inside_string_placeholder:
+    - meta_scope: constant.other.placeholder.cs
+    - include: string_placeholder_end
+    - include: string_placeholder_format
+    - match: '[^"}]+'
+      scope: invalid.illegal.unexpected-character-in-placeholder.cs
+
+  inside_long_string_placeholder:
+    - meta_scope: constant.other.placeholder.cs
+    - include: string_placeholder_end
+    - include: long_string_placeholder_format
+    - match: '[^"}]+'
+      scope: invalid.illegal.unexpected-character-in-placeholder.cs
+
+  string_placeholder_end:
     - match: '(\})(\}(?!\}))?'
       captures:
         1: punctuation.definition.placeholder.end.cs
@@ -1874,20 +1888,6 @@ contexts:
       pop: true
     - match: (?=[}"])
       pop: true
-
-  string_placeholder:
-    - meta_scope: constant.other.placeholder.cs
-    - include: inside_string_placeholder
-    - include: string_placeholder_format
-    - match: '[^"}]+'
-      scope: invalid.illegal.unexpected-character-in-placeholder.cs
-
-  long_string_placeholder:
-    - meta_scope: constant.other.placeholder.cs
-    - include: inside_string_placeholder
-    - include: long_string_placeholder_format
-    - match: '[^"}]+'
-      scope: invalid.illegal.unexpected-character-in-placeholder.cs
 
   string_placeholder_format_before_colon:
     - match: '\s*(?:(,)\s*((-?)\d+)\s*)?'
@@ -1948,7 +1948,7 @@ contexts:
       pop: true
     - include: line_of_code_in
 
-  long_string:
+  inside_long_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.raw.cs
     - include: long_string_escaped
@@ -1957,7 +1957,7 @@ contexts:
       captures:
         1: punctuation.definition.placeholder.begin.cs
         2: meta.number.integer.decimal.cs constant.numeric.value.cs
-      push: long_string_placeholder
+      push: inside_long_string_placeholder
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1728,7 +1728,7 @@ contexts:
 
   inside_string:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.cs
+    - meta_scope: meta.string.cs string.quoted.double.cs
     - include: string_escaped
     - match: '"'
       scope: punctuation.definition.string.end.cs
@@ -1751,14 +1751,7 @@ contexts:
       pop: true
     - include: string_escaped
     - include: string_placeholder_escape
-    - match: \{
-      scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: string_placeholder_format
-        - include: string_interpolation
+    - include: format_string_interpolation
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
@@ -1771,14 +1764,7 @@ contexts:
       pop: true
     - include: string_escaped
     - include: string_placeholder_escape
-    - match: \{
-      scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: string_placeholder_format
-        - include: string_interpolation
+    - include: format_string_interpolation
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
@@ -1790,17 +1776,25 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholder_escape
-    - match: \{
-      scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: string_placeholder_format
-        - include: string_interpolation
+    - include: format_string_interpolation
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
       pop: true
+
+  format_string_interpolation:
+    - match: \{
+      scope: punctuation.section.interpolation.begin.cs
+      push: inside_format_string_interpolation
+
+  inside_format_string_interpolation:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.cs
+    - meta_content_scope: source.cs
+    - match: '\}'
+      scope: punctuation.section.interpolation.end.cs
+      pop: true
+    - include: string_placeholder_format
+    - include: line_of_code_in
 
   inside_raw_format_string_2:
     - meta_include_prototype: false
@@ -1810,14 +1804,7 @@ contexts:
       pop: true
     - include: string_escaped
     - include: string_placeholder_escape
-    - match: \{\{
-      scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: string_placeholder_format
-        - include: string_interpolation_2
+    - include: format_string_interpolation_2
 
   inside_raw_format_string_literal_2:
     - meta_include_prototype: false
@@ -1826,14 +1813,22 @@ contexts:
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholder_escape
-    - match: \{
+    - include: format_string_interpolation_2
+
+  format_string_interpolation_2:
+    - match: \{\{
       scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: string_placeholder_format
-        - include: string_interpolation_2
+      push: inside_format_string_interpolation_2
+
+  inside_format_string_interpolation_2:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.cs
+    - meta_content_scope: source.cs
+    - match: '\}\}'
+      scope: punctuation.section.interpolation.end.cs
+      pop: true
+    - include: string_placeholder_format
+    - include: line_of_code_in
 
   inside_long_format_string:
     - meta_include_prototype: false
@@ -1845,12 +1840,17 @@ contexts:
     - include: string_placeholder_escape
     - match: \{
       scope: punctuation.section.interpolation.begin.cs
-      push:
-        - meta_scope: meta.string.interpolated.cs
-        - meta_content_scope: source.cs
-        - clear_scopes: 2
-        - include: long_string_placeholder_format
-        - include: string_interpolation
+      push: inside_long_format_string_interpolation
+
+  inside_long_format_string_interpolation:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.cs
+    - meta_content_scope: source.cs
+    - match: '\}'
+      scope: punctuation.section.interpolation.end.cs
+      pop: true
+    - include: long_string_placeholder_format
+    - include: line_of_code_in
 
   string_placeholder_escape:
     - match: '\{\{|\}\}'
@@ -1935,18 +1935,6 @@ contexts:
           pop: true
         - match: \{
           scope: invalid.illegal.unescaped-placeholder.cs
-
-  string_interpolation:
-    - match: '\}'
-      scope: punctuation.section.interpolation.end.cs
-      pop: true
-    - include: line_of_code_in
-
-  string_interpolation_2:
-    - match: '\}\}'
-      scope: punctuation.section.interpolation.end.cs
-      pop: true
-    - include: line_of_code_in
 
   inside_long_string:
     - meta_include_prototype: false

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -39,6 +39,13 @@ var location = $$"""
 var pointMessage = $"""The point "{X}, {Y}" is {Math.Sqrt(X * X + Y * Y)} from the origin""";
 ///                ^^^^ meta.string.interpolated string.quoted.triple punctuation.definition.string.begin
 ///                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated
+///                    ^^^^^^^^^^^ string.quoted.triple - meta.interpolation
+///                               ^^^ meta.interpolation - string
+///                                  ^^ string.quoted.triple - meta.interpolation
+///                                    ^^^ meta.interpolation - string
+///                                       ^^^^^ string.quoted.triple - meta.interpolation
+///                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation - string
+///                                                                      ^^^^^^^^^^^^^^^^^^^ string.quoted.triple - meta.interpolation
 ///                               ^ punctuation.section.interpolation.begin
 ///                                ^ variable.other
 ///                                 ^ punctuation.section.interpolation.end


### PR DESCRIPTION
This PR proposes to ...

1. rename string content contexts to `inside_...`.
2. add named contexts for interpolation related contexts
3. add named contexts for extended placeholders
4. fixes an issue with `{` instead of `{{` being used in one of the `format_string_..._2` contexts.
5. scopes interpolating expressions `meta.interpolation`