### PR TITLE
[Go] Two more things.

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -235,25 +235,25 @@ contexts:
   match-comment-magic-language-injection-language-id:
     - meta_scope: comment.line.double-slash.go
     - match: (?i)css\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.css#match-comment-magic-language-injection-inner
     - match: (?i)html\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.html#match-comment-magic-language-injection-inner
     - match: (?i)js\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.js#match-comment-magic-language-injection-inner
     - match: (?i)json\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.json#match-comment-magic-language-injection-inner
     - match: (?i)regexp\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.regexp#match-comment-magic-language-injection-inner
     - match: (?i)sql\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.sql#match-comment-magic-language-injection-inner
     - match: (?i)xml\b
-      scope: meta.annotation.parameters.go constant.language.go
+      scope: meta.annotation.parameters.go constant.other.language-name.go
       set: scope:source.go.embedded-backtick-string.xml#match-comment-magic-language-injection-inner
     - match: (?=\S)
       set: pop-comment-line-normal

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -255,6 +255,8 @@ contexts:
     - match: (?i)xml\b
       scope: meta.annotation.parameters.go constant.language.go
       set: scope:source.go.embedded-backtick-string.xml#match-comment-magic-language-injection-inner
+    - match: (?=\S)
+      set: pop-comment-line-normal
     - include: pop-on-eol
 
   pop-line-annotation:

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -5434,7 +5434,7 @@ func lang_embedding() {
     // <- comment.line.double-slash.go meta.annotation.identifier.go punctuation.definition.comment.go
     //^^^^^^^^ comment.line.double-slash.go meta.annotation.identifier.go support.other.go
     //        ^ comment.line.double-slash.go meta.annotation.identifier.go keyword.operator.assignment.go
-    //         ^^^^ comment.line.double-slash.go
+    //         ^^^^ comment.line.double-slash.go - constant
 
     //language=any css
     // <- comment.line.double-slash.go meta.annotation.identifier.go punctuation.definition.comment.go
@@ -5443,6 +5443,10 @@ func lang_embedding() {
     //         ^^^^^^^^ comment.line.double-slash.go - constant
 
     //language=css
+    //^^^^^^^^^^^^^ comment.line.double-slash.go
+    //^^^^^^^^ meta.annotation.identifier.go support.other.go
+    //        ^ meta.annotation.identifier.go keyword.operator.assignment.go
+    //         ^^^ meta.annotation.parameters.go constant.other.language-name.go
     css_string := `.class { color: #fff }`
     //            ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go - source.css
     //             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go source.css.embedded.go - string.quoted.backtick
@@ -5451,6 +5455,9 @@ func lang_embedding() {
     //language=html prefix=<body> suffix=</body>
     // <- comment.line.double-slash.go meta.annotation.identifier.go punctuation.definition.comment.go
     //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.go
+    //^^^^^^^^ meta.annotation.identifier.go support.other.go
+    //        ^ meta.annotation.identifier.go keyword.operator.assignment.go
+    //         ^^^^ meta.annotation.parameters.go constant.other.language-name.go
     html_string := `<h1 style="color:red">Title</h2>`
     //             ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go
     //              ^^^^^^^^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go text.html.embedded.go meta.tag
@@ -5459,6 +5466,10 @@ func lang_embedding() {
     //                                              ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.end.go
 
     //language=js
+    //^^^^^^^^^^^^ comment.line.double-slash.go
+    //^^^^^^^^ meta.annotation.identifier.go support.other.go
+    //        ^ meta.annotation.identifier.go keyword.operator.assignment.go
+    //         ^^ meta.annotation.parameters.go constant.other.language-name.go
     js_string := `var i = 0`
     //           ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go - source.js
     //            ^^^^^^^^^ meta.string.go meta.embedded.go source.js.embedded.go - string.quoted.backtick
@@ -5469,7 +5480,7 @@ func lang_embedding() {
     //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.go
     //^^^^^^^^ meta.annotation.identifier.go
     //        ^ meta.annotation keyword.operator.assignment.go
-    //         ^^^ meta.annotation.parameters.go constant.language.go
+    //         ^^^ meta.annotation.parameters.go constant.other.language-name.go
     sqlQuery := `
     //          ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go
     //           ^ meta.string.go meta.embedded.go source.sql.embedded.go
@@ -5519,6 +5530,10 @@ func lang_embedding() {
     //           ^ punctuation.separator.go - string
 
     // language=regexp
+    //^^^^^^^^^^^^^^^^^ comment.line.double-slash.go
+    // ^^^^^^^^ meta.annotation.identifier.go support.other.go
+    //         ^ meta.annotation.identifier.go keyword.operator.assignment.go
+    //          ^^^^^^ meta.annotation.parameters.go constant.other.language-name.go
     pattern := `ab?c+`
     //         ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go - source.regexp
     //          ^^^^^ meta.string.regexp.go source.regexp.embedded.go meta.mode.basic.regexp
@@ -5526,6 +5541,10 @@ func lang_embedding() {
     //               ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.end.go
 
     //language=xml prefix=<svg> suffix=</svg>
+    //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.go
+    //^^^^^^^^ meta.annotation.identifier.go support.other.go
+    //        ^ meta.annotation.identifier.go keyword.operator.assignment.go
+    //         ^^^ meta.annotation.parameters.go constant.other.language-name.go
     image := `<path d="M 0.0 10.0" fill="#000" />`
     //       ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go
     //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go text.xml.embedded.go meta.tag.xml

--- a/Go/syntax_test_go.go
+++ b/Go/syntax_test_go.go
@@ -5436,6 +5436,12 @@ func lang_embedding() {
     //        ^ comment.line.double-slash.go meta.annotation.identifier.go keyword.operator.assignment.go
     //         ^^^^ comment.line.double-slash.go
 
+    //language=any css
+    // <- comment.line.double-slash.go meta.annotation.identifier.go punctuation.definition.comment.go
+    //^^^^^^^^ comment.line.double-slash.go meta.annotation.identifier.go support.other.go
+    //        ^ comment.line.double-slash.go meta.annotation.identifier.go keyword.operator.assignment.go
+    //         ^^^^^^^^ comment.line.double-slash.go - constant
+
     //language=css
     css_string := `.class { color: #fff }`
     //            ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go - source.css


### PR DESCRIPTION

This PR fixes an issue which causes `language=foo css` to be detected as CSS langauge injection, even though `foo` was given as unknown language Id.

I'd also propose to use `constant.other.language-name` for the language id, primarily because that scope is already used in Markdown and Perl, for exactly the same thing.
