### PR TITLE
[SQL] Fix identifier interpolation

### DIFF
--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -5998,9 +5998,13 @@ func lang_embedding() {
     require.Equal(t, 1, testdb.QueryInt(env.testDb, `select count(*) from "schema.{{.site.table}}" order by {{.order}}`))
     //                                              ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.begin.go
     //                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go source.sql.embedded.go
-    //                                                                            ^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go source.sql.embedded.go - string
+    //                                                                            ^^^^^^^^^^^^^^^ meta.string.go meta.embedded.go source.sql.embedded.go meta.table-name.sql meta.interpolation.go - string
+    //                                                                            ^^ punctuation.section.interpolation.begin.go
+    //                                                                                         ^^ punctuation.section.interpolation.end.go
     //                                                                                           ^^^^^^^^^^^ meta.block.go meta.string.go meta.embedded.go
     //                                                                                                      ^^^^^^^^^^ meta.string.go meta.embedded.go source.sql.embedded.go meta.interpolation.go - string
+    //                                                                                                      ^^ punctuation.section.interpolation.begin.go
+    //                                                                                                              ^^ punctuation.section.interpolation.end.go
     //                                                                                                                ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.end.go
     //                                               ^^^^^^ keyword.other
     not_sql_string = `select not sql`

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -1405,7 +1405,6 @@ contexts:
 
   inside-double-quoted-identifier-part:
     # note: may contain foreign variable interpolation
-    - meta_include_prototype: false
     - match: \"
       scope: punctuation.definition.identifier.end.sql
       pop: 1


### PR DESCRIPTION
Interpolation in identifers was broken just because a - `meta_include_prototype`.

We don't need it in identifiers as we don't need to clear any string scopes and thus can inject normal `prototype`.