### PR TITLE
[C#] Include SQL in "long" strings

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -53,6 +53,18 @@ variables:
 
   method_param_type_modifier: \b(?:out|ref|this|params|in)\b
 
+  sql_indicator: |-
+    (?x: \s* (?:
+    # dml statements
+      SELECT | INSERT | REPLACE | DELETE | TRUNCATE | UPDATE
+    # ddl statements
+    | ADD | ALTER | CREATE | DROP
+    # conditional
+    | IF \s+ (?: NOT \s+ )? EXISTS
+    # declaration
+    | DECLARE | WITH
+    ) \s )
+
 contexts:
   prototype:
     - include: comments
@@ -1850,11 +1862,15 @@ contexts:
     # multi-line strings
     - match: '@"'
       scope: punctuation.definition.string.begin.cs
-      push: inside_long_string
+      push:
+        - inside_long_string
+        - inside_long_string_syntax
     # interpolated multi-line strings
     - match: '(@\$|\$@)"'
       scope: punctuation.definition.string.begin.cs
-      push: inside_long_format_string
+      push:
+        - inside_long_format_string
+        - inside_long_format_string_syntax
 
   inside_raw_string_literal:
     - meta_include_prototype: false
@@ -1972,6 +1988,21 @@ contexts:
       scope: punctuation.section.interpolation.begin.cs
       push: inside_long_format_string_interpolation
 
+  inside_long_format_string_syntax:
+    - meta_include_prototype: false
+    - match: (?={{sql_indicator}})
+      set: scope:source.sql
+      with_prototype:
+        - include: long_string_escaped
+        - match: (?=")
+          pop: true
+        - include: string_placeholder_escape
+        - match: \{
+          scope: punctuation.section.interpolation.begin.cs
+          push: inside_long_format_string_interpolation
+    - match: (?=\S)
+      pop: true
+
   inside_long_format_string_interpolation:
     - clear_scopes: 1
     - meta_scope: meta.interpolation.cs
@@ -2082,13 +2113,26 @@ contexts:
 
   inside_long_string:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.raw.cs
+    - meta_scope: meta.string.cs string.quoted.double.raw.cs
     - include: long_string_escaped
     - match: '"'
       scope: punctuation.definition.string.end.cs
       pop: true
     - include: string_placeholders
     - include: extended_long_string_placeholders
+
+  inside_long_string_syntax:
+    - meta_include_prototype: false
+    - match: (?={{sql_indicator}})
+      set: scope:source.sql
+      with_prototype:
+        - include: long_string_escaped
+        - match: (?=")
+          pop: true
+        - include: string_placeholders
+        - include: extended_long_string_placeholders
+    - match: (?=\S)
+      pop: true
 
   escaped:
     - match: '{{escaped_char}}'

--- a/C#/tests/syntax_test_Strings.cs
+++ b/C#/tests/syntax_test_Strings.cs
@@ -1,5 +1,19 @@
 /// SYNTAX TEST "Packages/C#/C#.sublime-syntax"
 
+var character = 'y';
+/// ^^^^^^^^^ variable.other.cs
+///           ^ keyword.operator.assignment.variable.cs
+///             ^^^ meta.string.cs string.quoted.single.cs
+///             ^ punctuation.definition.string.begin.cs
+///              ^ constant.character.literal.cs
+///               ^ punctuation.definition.string.end.cs
+///                ^ punctuation.terminator.statement.cs
+var character_too_long = 'no';
+/// ^^^^^^^^^^^^^^^^^^ variable.other.cs
+///                    ^ keyword.operator.assignment.variable.cs
+///                      ^^^^ invalid.illegal.not_a_char.cs
+///                          ^ punctuation.terminator.statement.cs
+
 "short unicode \u1234";
 ///<- string.quoted.double.cs
 ///            ^^^^^^ constant.character.escape.cs
@@ -27,20 +41,20 @@
 ///                                           ^^ constant.character.escape.cs
 
 var literal = "foo";
-///           ^^^^^ string.quoted.double
+///           ^^^^^ string.quoted.double - meta.string.interpolated
 var interpolated_none = $"foo";
 ///                     ^^^^^^ meta.string.interpolated.cs string.quoted.double.cs
 var interpolated_yes = $"foo {bar} foo";
 ///                    ^^^^^^^^^^^^^^^^ meta.string.interpolated.cs
 var verbatim_singleline = @"foo";
-///                       ^^^^^^ string.quoted.double.raw.cs
+///                       ^^^^^^ meta.string.cs string.quoted.double.raw.cs - meta.string.interpolated
 var verbatim_singleline_interpolated_none = $@"foo bar";
 ///                                         ^^^^^^^^^^^ meta.string.interpolated.cs string.quoted.double.raw.cs
 var verbatim_singleline_interpolated_yes = $@"foo {bar} foo";
 ///                                        ^^^^^^^ string.quoted.double.raw.cs
 ///                                        ^^^^^^^^^^^^^^^^^ meta.string.interpolated.cs
 var verbatim_multiline = @"foo bar
-///                      ^^^^^^^^^^ string.quoted.double.raw.cs
+///                      ^^^^^^^^^^ meta.string.cs string.quoted.double.raw.cs - meta.string.interpolated
 baz";
 var verbatim_multiline_interpolated_none = $@"foo bar
 ///                                        ^^^^^^^^^^^ meta.string.interpolated.cs string.quoted.double.raw.cs
@@ -49,6 +63,44 @@ var verbatim_multiline_interpolated_yes = $@"foo {bar}
 ///                                       ^^^^^^ string.quoted.double.raw.cs
 ///                                       ^^^^^^^^^^^^ meta.string.interpolated.cs
 baz";
+
+var verbatim_singleline_sql = @"
+    SELECT  *
+    FROM    foo
+    WHERE   SQLi='{0}'";
+///^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.quoted.double.raw.cs - meta.string.interpolated
+///^^^^^^^^^^^^^^^^^^^ source.sql
+/// ^^^^^ keyword.other.dml.sql
+///         ^^^^ meta.column-name.sql
+///             ^ keyword.operator.comparison.sql
+///              ^^^^^ meta.string.sql string.quoted.single.sql
+///              ^ punctuation.definition.string.begin.sql
+///               ^^^ constant.other.placeholder.cs
+///               ^ punctuation.definition.placeholder.begin.cs
+///                ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                 ^ punctuation.definition.placeholder.end.cs
+///                  ^ punctuation.definition.string.end.sql
+///                   ^ punctuation.definition.string.end.cs
+///                    ^ punctuation.terminator.statement.cs
+
+var verbatim_singleline_sql_interpolated = $@"
+    SELECT  *
+    FROM    foo
+    WHERE   SQLi='{bar}'";
+///^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated.cs string.quoted.double.raw.cs
+///^^^^^^^^^^^^^^^^^^^^^ source.sql
+/// ^^^^^ keyword.other.dml.sql
+///         ^^^^ meta.column-name.sql
+///             ^ keyword.operator.comparison.sql
+///              ^^^^^^^ meta.string.sql
+///              ^ string.quoted.single.sql punctuation.definition.string.begin.sql
+///               ^^^^^ meta.interpolation.cs
+///               ^ punctuation.section.interpolation.begin.cs
+///                ^^^ source.cs variable.other.cs
+///                   ^ punctuation.section.interpolation.end.cs
+///                    ^ string.quoted.single.sql punctuation.definition.string.end.sql
+///                     ^ punctuation.definition.string.end.cs
+///                      ^ punctuation.terminator.statement.cs
 
     "{32F31D43-81CC-4C15-9DE6-3FC5453562B6}"
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double


### PR DESCRIPTION
This is effectively the same thing for `@"` and `$@"` strings, formatted like DeathAxe suggested.